### PR TITLE
[Frontend] 데스크탑/모바일 메뉴 레이아웃 개선

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import 'normalize.css'
 import 'antd/dist/antd.css'
+import './style.css'
 
 import React from 'react'
 

--- a/pages/style.css
+++ b/pages/style.css
@@ -23,3 +23,18 @@ h5,
 h6 {
   margin: 0;
 }
+
+.ant-drawer-header {
+  background-color: #001529;
+  border-radius: 0;
+}
+
+.ant-drawer-title {
+  color: #fff;
+}
+
+.ant-drawer-body {
+  background-color: #001529;
+  color: #fff;
+  height: calc(100vh - 55px);
+}

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -67,14 +67,9 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
         overlay={
           <Menu>
             <Menu.Item>
-              <a target="_blank" rel="noopener noreferrer" href="#">
-                마이페이지
-              </a>
-            </Menu.Item>
-            <Menu.Item>
-              <a target="_blank" rel="noopener noreferrer" href="#">
-                회원정보 수정
-              </a>
+              <Link href="/mypage">
+                <a>마이페이지</a>
+              </Link>
             </Menu.Item>
             <Menu.Item onClick={onClickLogout}>
               <a>로그아웃</a>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -48,7 +48,7 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
     return (
       <Button>
         <Link href="/login">
-          <a>로그인 · 회원가입</a>
+          <a>로그인</a>
         </Link>
      </Button>
     )

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -46,18 +46,11 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
 
   const loggedOutUserMenu = () => {
     return (
-      <Space size="middle">
-        <Button>
-          <Link href="/login">
-              <a>로그인</a>
-            </Link>
-        </Button>
-        <Button>
-          <Link href="/register">
-            <a>회원가입</a>
-          </Link>
-        </Button>
-      </Space>
+      <Button>
+        <Link href="/login">
+          <a>로그인 · 회원가입</a>
+        </Link>
+     </Button>
     )
   }
 
@@ -74,11 +67,16 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
             <Menu.Item onClick={onClickLogout}>
               <a>로그아웃</a>
             </Menu.Item>
+            <Menu.Item>
+              <Link href="/metest">
+                <a>내정보 로드 테스트</a>
+              </Link>
+            </Menu.Item>
           </Menu>
         }
         placement="bottomRight"
         arrow>
-        <Button>{<UserOutlined />}User</Button>
+        <Button>{<UserOutlined />}{me?.nickname}</Button>
       </Dropdown>
     )
   }
@@ -101,7 +99,7 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
               <Col>{MenuDrawer()}</Col>
               <Col span={10}></Col>
               <Col>
-                { me ? loggedInUserMenu() : loggedOutUserMenu() }
+                { me?._id ? loggedInUserMenu() : loggedOutUserMenu() }
               </Col>
               <Col span={1}></Col>
             </Row>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -7,6 +7,7 @@ import 'antd/dist/antd.css'
 import { useRouter } from 'next/dist/client/router'
 import cookie from 'react-cookies'
 import { useRecoilState, useSetRecoilState } from 'recoil'
+import Link from 'next/link'
 
 import { categoriesState, loadCategories } from 'src/state/categories'
 
@@ -43,6 +44,50 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
     return
   }
 
+  const loggedOutUserMenu = () => {
+    return (
+      <Space size="middle">
+        <Button>
+          <Link href="/login">
+              <a>로그인</a>
+            </Link>
+        </Button>
+        <Button>
+          <Link href="/register">
+            <a>회원가입</a>
+          </Link>
+        </Button>
+      </Space>
+    )
+  }
+
+  const loggedInUserMenu = () => {
+    return (
+      <Dropdown
+        overlay={
+          <Menu>
+            <Menu.Item>
+              <a target="_blank" rel="noopener noreferrer" href="#">
+                마이페이지
+              </a>
+            </Menu.Item>
+            <Menu.Item>
+              <a target="_blank" rel="noopener noreferrer" href="#">
+                회원정보 수정
+              </a>
+            </Menu.Item>
+            <Menu.Item onClick={onClickLogout}>
+              <a>로그아웃</a>
+            </Menu.Item>
+          </Menu>
+        }
+        placement="bottomRight"
+        arrow>
+        <Button>{<UserOutlined />}User</Button>
+      </Dropdown>
+    )
+  }
+
   return (
     <>
       <Layout>
@@ -61,30 +106,7 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
               <Col>{MenuDrawer()}</Col>
               <Col span={10}></Col>
               <Col>
-                <Space size="middle">
-                  <Dropdown
-                    overlay={
-                      <Menu>
-                        <Menu.Item>
-                          <a target="_blank" rel="noopener noreferrer" href="#">
-                            마이페이지
-                          </a>
-                        </Menu.Item>
-                        <Menu.Item>
-                          <a target="_blank" rel="noopener noreferrer" href="#">
-                            회원정보 수정
-                          </a>
-                        </Menu.Item>
-                        <Menu.Item onClick={onClickLogout}>
-                          <a>로그아웃</a>
-                        </Menu.Item>
-                      </Menu>
-                    }
-                    placement="bottomRight"
-                    arrow>
-                    <Button>{<UserOutlined />}User</Button>
-                  </Dropdown>
-                </Space>
+                { me ? loggedInUserMenu() : loggedOutUserMenu() }
               </Col>
               <Col span={1}></Col>
             </Row>

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react'
 
-import { MenuOutlined } from '@ant-design/icons'
+import { MenuOutlined, FileTextTwoTone } from '@ant-design/icons'
 import { Button, Drawer } from 'antd'
+
+import { FlexDiv } from 'style/div'
+
+import Link from 'next/link'
 
 import { xs, useWindowSize } from 'src/utils/size'
 
@@ -29,7 +33,24 @@ const MenuDrawer = () => {
           closable={false}
           onClose={onClose}
           visible={visible}>
-          <MenuLayout />
+          <Link href="/">
+            <a onClick={onClose}>
+              <FlexDiv justify={'center'} align={'center'}>
+                <FileTextTwoTone
+                  twoToneColor="#005f99"
+                  style={{
+                    fontSize: '2rem',
+                    color: '#08c',
+                    margin: '0.5rem 0',
+                  }}
+                />
+                <h1 style={{ color: '#C3D4D9', margin: '0 0.5rem' }}>
+                    Kramo
+                </h1>
+              </FlexDiv>
+            </a>
+          </Link>
+          <MenuLayout/>
         </Drawer>
       </>
     )

--- a/src/components/MenuLayout.tsx
+++ b/src/components/MenuLayout.tsx
@@ -90,13 +90,15 @@ const MenuLayout = () => {
         title="카테고리를 추가하시겠습니까?"
         visible={isModalVisible}
         onOk={handleOk}
-        onCancel={handleCancel}>
+        onCancel={handleCancel}
+        destroyOnClose={true}>
         <Input
           value={categoryValue}
           onChange={(e) => {
             setCategoryValue(e.target.value)
           }}
           placeholder="카테고리명"
+          autoFocus={true}
         />
       </Modal>
       <Divider style={{ color: MENU_LABEL_COLOR }} />

--- a/src/components/MenuLayout.tsx
+++ b/src/components/MenuLayout.tsx
@@ -2,14 +2,11 @@ import React, { useState } from 'react'
 
 import {
   PlusCircleOutlined,
-  UserAddOutlined,
-  UserOutlined,
+  FolderFilled,
   BookTwoTone,
-  AppstoreTwoTone,
 } from '@ant-design/icons'
 import { Divider, Input, Menu, message, Typography } from 'antd'
 import Modal from 'antd/lib/modal/Modal'
-import Link from 'next/link'
 import { useRecoilState, useRecoilValue } from 'recoil'
 
 import {
@@ -32,20 +29,6 @@ const CategoryTitleLabel = ({ collapsed }: { collapsed: boolean }) => {
       ) : (
         <Typography.Title level={4} style={{ color: MENU_LABEL_COLOR }}>
           카테고리
-        </Typography.Title>
-      )}
-    </FlexDiv>
-  )
-}
-
-const ElseLabel = ({ collapsed }: { collapsed: boolean }) => {
-  return (
-    <FlexDiv>
-      {collapsed ? (
-        <AppstoreTwoTone twoToneColor="white" style={{ fontSize: '1.5rem' }} />
-      ) : (
-        <Typography.Title level={4} style={{ color: MENU_LABEL_COLOR }}>
-          기타 메뉴
         </Typography.Title>
       )}
     </FlexDiv>
@@ -81,6 +64,7 @@ const MenuLayout = () => {
     message.info('카테고리 추가 성공!')
   }
 
+
   const handleCancel = () => {
     setIsModalVisible(false)
   }
@@ -102,11 +86,13 @@ const MenuLayout = () => {
         />
       </Modal>
       <Divider style={{ color: MENU_LABEL_COLOR }} />
-      <CategoryTitleLabel collapsed={menuCollapsed} />
+      <CategoryTitleLabel collapsed={menuCollapsed} /><br/>
       <Menu style={{ zIndex: 5 }} mode="inline" theme="dark">
         {categories.map((category: CategoryInfo) => {
           return (
-            <Menu.Item key={`menu_${category._id}`}>{category.name}</Menu.Item>
+            <Menu.Item key={`menu_${category._id}`} icon={<FolderFilled/>}>
+              {category.name}
+            </Menu.Item>
           )
         })}
         {categoryAddAvail ? (
@@ -116,31 +102,6 @@ const MenuLayout = () => {
         ) : (
           ''
         )}
-        <Divider style={{ color: MENU_LABEL_COLOR }} />
-        <ElseLabel collapsed={menuCollapsed} />
-        {me?._id ? (
-          <Menu.Item key="2" icon={<UserOutlined />}>
-            <Link href="/mypage">
-              <a>마이페이지</a>
-            </Link>
-          </Menu.Item>
-        ) : (
-          <Menu.Item key="2" icon={<UserOutlined />}>
-            <Link href="/login">
-              <a>로그인</a>
-            </Link>
-          </Menu.Item>
-        )}
-        <Menu.Item key="3" icon={<UserAddOutlined />}>
-          <Link href="/register">
-            <a>회원가입</a>
-          </Link>
-        </Menu.Item>
-        <Menu.Item key="4" icon={<UserOutlined />}>
-          <Link href="/metest">
-            <a>내정보 로드 테스트</a>
-          </Link>
-        </Menu.Item>
       </Menu>
     </>
   )


### PR DESCRIPTION
* 우측 상단의 메뉴를 로그인했을 때와 로그인하지 않았을 때로 변경
* 기존의 회원가입 메뉴 삭제
* 기존 좌측 하단의 로그인/내정보 로드 테스트 우측 상단 버튼의 dropdown으로 이동
* 모바일 Drawer에 바뀐 왼쪽 메뉴 레이아웃 적용


데스크탑 
<img width="1792" alt="스크린샷 2021-06-13 00 56 45" src="https://user-images.githubusercontent.com/52598392/121782095-e7fb8500-cbe2-11eb-8763-d7cc4cedacd5.png">
<img width="1792" alt="스크린샷 2021-06-13 00 57 09" src="https://user-images.githubusercontent.com/52598392/121782110-f9dd2800-cbe2-11eb-9125-73e827a3774e.png">
<img width="1792" alt="스크린샷 2021-06-13 00 57 20" src="https://user-images.githubusercontent.com/52598392/121782113-fe094580-cbe2-11eb-9030-8a0a054e9edb.png">

모바일
<img width="373" alt="스크린샷 2021-06-13 00 59 27" src="https://user-images.githubusercontent.com/52598392/121782144-1ed19b00-cbe3-11eb-9bc0-27432dbf3707.png">
<img width="373" alt="스크린샷 2021-06-13 00 59 31" src="https://user-images.githubusercontent.com/52598392/121782147-21cc8b80-cbe3-11eb-9162-b0273b0a1fe2.png">

