### PR TITLE
[Frontend] API 로딩 최적화 - 로딩 바(Spinner) 구현 및 getServersideProps 이용

### DIFF
--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -10,6 +10,7 @@ import AskAgainButton from 'src/components/AskAgain'
 import kaxios from 'src/interceptors'
 import { meState } from 'src/state/me'
 import { FlexDiv } from 'style/div'
+import { Spinner } from 'src/components/Spinner'
 
 const myLabelStyle: CSSProperties = {
   color: 'black',
@@ -31,6 +32,7 @@ DescriptionsItem.defaultProps = {
 const Mypage = () => {
   const [me, setMe] = useRecoilState(meState)
   const router = useRouter()
+  const [loading, setLoading] = useState<boolean>(false)
   const [onUpdateMode, setOnUpdateMode] = useState<boolean>(false)
   const [updateValues, setUpdateValues] = useState<{
     name?: string
@@ -48,7 +50,7 @@ const Mypage = () => {
       return
     }
     setUpdateValues(_.pick(me, 'name', 'nickname', 'mobile'))
-  }, [me, router, onUpdateMode])
+  }, [me, router, onUpdateMode, loading])
 
   const onClickUpdateButton = () => {
     setOnUpdateMode(!onUpdateMode)
@@ -63,6 +65,7 @@ const Mypage = () => {
       message.warning('변경사항이 없습니다!')
       return
     }
+    setLoading(true)
     try {
       const updatedUser = await kaxios({
         url: `/user/${me?._id}`,
@@ -75,6 +78,11 @@ const Mypage = () => {
     } catch (e) {
       message.error('유저정보 업데이트가 실패했습니다.')
     }
+    setLoading(false)
+  }
+
+  if (loading) {
+    return <Spinner></Spinner>
   }
 
   return (

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,14 @@
+import { LoadingOutlined } from '@ant-design/icons'
+import { Spin } from 'antd'
+
+import { FlexDiv } from 'style/div'
+
+const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />
+
+export const Spinner = () => {
+  return (
+    <FlexDiv width="100%" height="100%">
+      <Spin indicator={antIcon} />
+    </FlexDiv>
+  )
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -5,9 +5,14 @@ import { FlexDiv } from 'style/div'
 
 const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />
 
-export const Spinner = () => {
+interface SpinnerProps {
+  width?: string
+  height?: string
+}
+
+export const Spinner = ({ width = '100%', height = '100%' }: SpinnerProps) => {
   return (
-    <FlexDiv width="100%" height="100%">
+    <FlexDiv width={width} height={height}>
       <Spin indicator={antIcon} />
     </FlexDiv>
   )

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -7,7 +7,7 @@ import axios from 'axios'
 */
 const kaxios = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_SERVICE_URL}/api`,
-  timeout: 1500,
+  timeout: 15000,
   withCredentials: true,
 })
 


### PR DESCRIPTION
## PR 내용

현재, 페이지 로드 및 이벤트 발생 시에 화면이 바로 보이지 않거나, 깜빡이는 문제가 있습니다. 

이는 Client 비동기 호출로 인해 UI 에 필요한 데이터 로드에 지연이 생기기 때문인데, 다음과 같은 방법으로 해결하고자 합니다!

1. 로딩 바 (Spinner) 이용

2. `getServersideProps` 을 이용해 서버사이드 렌더링화

### 로딩 바 이용

![스피너예시](https://user-images.githubusercontent.com/28820058/122178092-3c438500-cec1-11eb-95bb-52e6102a793d.gif)

`/src/components/Spinner.tsx` 에 로딩 보여주기용 Spinner  컴퍼넌트를 만들었습니다.
필요하다면 loading 중에 이 컴퍼넌트를 띄우면 좋을 것 같습니다.
- width 및 height 설정 가능

#### 예시

![스피너예시2](https://user-images.githubusercontent.com/28820058/122178137-482f4700-cec1-11eb-9ab3-bc52392066f7.gif)

### 서버사이드 렌더링 이용

가능한 부분들을 `getServersideProps`  를 이용해서 서버에서 처리하게끔 바꿀 예정입니다.
- 깜빡임 및 스피너 최소화