### PR TITLE
[Frontend] 메인 화면의 날씨/시간 표시 수정, 메모 추가 시 날씨 입력받도록 수정

### DIFF
--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -31,7 +31,7 @@ import { meState } from '../state/me'
 import { CategoryInfo } from '../types/category'
 import { MemoInfo } from '../types/memo'
 import { Spinner } from './Spinner'
-import { defaultGPS, getLocation, getPlace } from 'src/utils/gps'
+import { DEFAULT_GPS, getLocation, getPlace } from 'src/utils/gps'
 import { GPS } from 'src/types'
 
 export function Main({ categoryId }: { categoryId?: string | undefined }) {
@@ -180,7 +180,7 @@ function AddCardButton({
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
   const [content, setContent] = useState<string>('')
   const [categoryId, setCategoryId] = useState<string>('')
-  const [GPS, setGPS] = useState<GPS>(defaultGPS)
+  const [GPS, setGPS] = useState<GPS>(DEFAULT_GPS)
   const CategoryPairs: { [key: string]: string } = {}
   const [categories] = useRecoilState(categoriesState)
   const [me] = useRecoilState(meState)

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -160,10 +160,12 @@ function MemoDetail({
   gps,
   weather,
   updatedAt,
+  darkMode,
 }: {
   gps: GPS
   weather: WeatherInfo
   updatedAt?: Date
+  darkMode: boolean
 }) {
   const { latitude, longitude } = gps
   const [place, setPlace] = useState<string>('알 수 없음')
@@ -178,7 +180,7 @@ function MemoDetail({
         <Col span={4} style={{ textAlign: 'center' }}>
           <img width="30" src={getIconURL(weather.icon)} />
         </Col>
-        <Col span={20}>
+        <Col span={20} style={darkMode ? {color: 'white'} : {}}>
           {updatedAt
             ? formatDate(new Date(updatedAt.toString()), new Date())
             : '알 수 없음'}
@@ -186,9 +188,11 @@ function MemoDetail({
       </Row>
       <Row>
         <Col span={4} style={{ textAlign: 'center' }}>
-          <EnvironmentOutlined />
+          {darkMode ? <EnvironmentOutlined style={{color: '#08c'}} /> : <EnvironmentOutlined />}
         </Col>
-        <Col span={20}>{`${place}`}</Col>
+        <Col span={20} style={darkMode ? {color: 'white'} : {}}>
+          {`${place}`}
+        </Col>
       </Row>
     </span>
   )
@@ -375,6 +379,7 @@ function MemoCardItem({
               gps={memo.gps}
               weather={memo.weather}
               updatedAt={memo.updatedAt}
+              darkMode={false}
             />
           </>
         }
@@ -399,6 +404,7 @@ function MemoCardItem({
             gps={memo.gps}
             weather={memo.weather}
             updatedAt={memo.updatedAt}
+            darkMode={true}
           />
         </Timeline>
         <Divider />

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -26,13 +26,20 @@ import Link from 'next/link'
 import { useRecoilState } from 'recoil'
 import { sm, md, useWindowSize } from 'src/utils/size'
 import useMemos from 'src/utils/useMemos'
-import { categoriesState } from '../state/categories'
-import { meState } from '../state/me'
-import { CategoryInfo } from '../types/category'
-import { MemoInfo } from '../types/memo'
+import { categoriesState } from 'src/state/categories'
+import { meState } from 'src/state/me'
+import { CategoryInfo } from 'src/types/category'
+import {
+  WeatherInfo,
+  getIconURL,
+  getNowWeatherByGeo,
+  EMPTY_WEATHER,
+} from 'src/utils/weather'
+import { MemoInfo } from 'src/types/memo'
 import { Spinner } from './Spinner'
 import { DEFAULT_GPS, getLocation, getPlace } from 'src/utils/gps'
 import { GPS } from 'src/types'
+import { formatDate } from 'src/utils/date'
 
 export function Main({ categoryId }: { categoryId?: string | undefined }) {
   const {
@@ -85,7 +92,13 @@ function MemoView({
   sortMemos,
 }: {
   memos: MemoInfo[]
-  addMemo: (memoId: string, category: string, text: string, gps: GPS) => void
+  addMemo: (
+    memoId: string,
+    category: string,
+    text: string,
+    gps: GPS,
+    weather: WeatherInfo,
+  ) => void
   deleteMemo: (memoId: string) => void
   sortMemos: (memoId: string) => void
 }) {
@@ -111,10 +124,7 @@ function MemoView({
               )
             })}
           <Col key={`ColAddCardButton`}>
-            <AddCardButton
-              key={`AddCardButton`}
-              addMemo={addMemo}
-            />
+            <AddCardButton key={`AddCardButton`} addMemo={addMemo} />
           </Col>
         </Row>
       </div>
@@ -146,7 +156,15 @@ function MemoTimeline() {
   else return <></>
 }
 
-function MemoDetail({ gps, weather, updatedAt }: any) {
+function MemoDetail({
+  gps,
+  weather,
+  updatedAt,
+}: {
+  gps: GPS
+  weather: WeatherInfo
+  updatedAt?: Date
+}) {
   const { latitude, longitude } = gps
   const [place, setPlace] = useState<string>('알 수 없음')
 
@@ -158,9 +176,13 @@ function MemoDetail({ gps, weather, updatedAt }: any) {
     <span>
       <Row>
         <Col span={4} style={{ textAlign: 'center' }}>
-          {weather.icon}
+          <img width="30" src={getIconURL(weather.icon)} />
         </Col>
-        <Col span={20}>{updatedAt}</Col>
+        <Col span={20}>
+          {updatedAt
+            ? formatDate(new Date(updatedAt.toString()), new Date())
+            : '알 수 없음'}
+        </Col>
       </Row>
       <Row>
         <Col span={4} style={{ textAlign: 'center' }}>
@@ -175,12 +197,20 @@ function MemoDetail({ gps, weather, updatedAt }: any) {
 function AddCardButton({
   addMemo,
 }: {
-  addMemo: (memoId: string, category: string, text: string, gps: GPS) => void
+  addMemo: (
+    memoId: string,
+    category: string,
+    text: string,
+    gps: GPS,
+    weather: WeatherInfo,
+  ) => void
 }) {
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
   const [content, setContent] = useState<string>('')
   const [categoryId, setCategoryId] = useState<string>('')
   const [GPS, setGPS] = useState<GPS>(DEFAULT_GPS)
+  const [currentWeather, setCurrentWeather] =
+    useState<WeatherInfo>(EMPTY_WEATHER)
   const CategoryPairs: { [key: string]: string } = {}
   const [categories] = useRecoilState(categoriesState)
   const [me] = useRecoilState(meState)
@@ -194,11 +224,18 @@ function AddCardButton({
         longitude: pos.coords.longitude,
       })
     })
+    getNowWeatherByGeo(
+      GPS.latitude,
+      GPS.longitude,
+      process.env.NEXT_PUBLIC_WEATHER_API_KEY!,
+    ).then((res) => {
+      setCurrentWeather(res)
+    })
     setIsModalVisible(true)
   }
 
   const handleOk = () => {
-    addMemo(me!._id!, categoryId, content, GPS)
+    addMemo(me!._id!, categoryId, content, GPS, currentWeather)
     setIsModalVisible(false)
   }
 
@@ -255,6 +292,12 @@ function AddCardButton({
           allowClear={true}
           onChange={(e) => setContent(e.target.value)}
         />
+        <Row>
+          <Col span={4} style={{ textAlign: 'center' }}>
+            <img width="30" src={getIconURL(currentWeather.icon)} />
+          </Col>
+          <Col span={20}>{currentWeather.description}</Col>
+        </Row>
         <Row>
           <Col span={4} style={{ textAlign: 'center' }}>
             <EnvironmentOutlined />

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -180,7 +180,7 @@ function MemoDetail({
         <Col span={4} style={{ textAlign: 'center' }}>
           <img width="30" src={getIconURL(weather.icon)} />
         </Col>
-        <Col span={20} style={darkMode ? {color: 'white'} : {}}>
+        <Col span={20} style={darkMode ? { color: 'white' } : {}}>
           {updatedAt
             ? formatDate(new Date(updatedAt.toString()), new Date())
             : '알 수 없음'}
@@ -188,9 +188,9 @@ function MemoDetail({
       </Row>
       <Row>
         <Col span={4} style={{ textAlign: 'center' }}>
-          {darkMode ? <EnvironmentOutlined style={{color: '#08c'}} /> : <EnvironmentOutlined />}
+          <EnvironmentOutlined style={darkMode ? { color: '#08c' } : {}} />
         </Col>
-        <Col span={20} style={darkMode ? {color: 'white'} : {}}>
+        <Col span={20} style={darkMode ? { color: 'white' } : {}}>
           {`${place}`}
         </Col>
       </Row>

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -1,5 +1,6 @@
-import { GPS, Weather } from './index'
-import { UserInfo } from './user'
+import { GPS } from 'src/types/index'
+import { WeatherInfo } from 'src/utils/weather'
+import { UserInfo } from 'src/types/user'
 
 export interface MemoInfo {
   _id: string
@@ -8,7 +9,7 @@ export interface MemoInfo {
   text: string
   user: UserInfo
   gps: GPS
-  weather: Weather
+  weather: WeatherInfo
   createdAt?: Date
   updatedAt?: Date
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -6,22 +6,22 @@ export const formatDate = (inputDate: Date, now: Date): string => {
   const year =
     inputDate.getFullYear() === now.getFullYear()
       ? ''
-      : `${inputDate.getFullYear()}년`
+      : `${inputDate.getFullYear()}년 `
 
   const date = today
     ? ''
-    : `${inputDate.getMonth() + 1}월 ${inputDate.getDate()}일`
+    : `${inputDate.getMonth() + 1}월 ${inputDate.getDate()}일 `
 
   const time = today
     ? compareTime(inputDate, now)
     : `${inputDate.getHours()}시 ${inputDate.getMinutes()}분`
-  return `${year} ${date} ${time}`
+  return `${year}${date}${time}`
 }
 
 const compareTime = (a: Date, b: Date): string => {
   const hoursCollapsed: number = b.getHours() - a.getHours()
   const minutesCollapsed: number =
-    (b.getHours() - a.getHours()) * 60 + b.getMinutes() - a.getMinutes()
+    hoursCollapsed * 60 + b.getMinutes() - a.getMinutes()
   return minutesCollapsed >= 60
     ? `${hoursCollapsed}시간 전`
     : `${minutesCollapsed}분 전`

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -19,10 +19,10 @@ export const formatDate = (inputDate: Date, now: Date): string => {
 }
 
 const compareTime = (a: Date, b: Date): string => {
-  const hoursCollapsed: number = b.getHours() - a.getHours()
-  const minutesCollapsed: number =
-    hoursCollapsed * 60 + b.getMinutes() - a.getMinutes()
-  return minutesCollapsed >= 60
-    ? `${hoursCollapsed}시간 전`
-    : `${minutesCollapsed}분 전`
+  const hoursElapsed: number = b.getHours() - a.getHours()
+  const minutesElapsed: number =
+    hoursElapsed * 60 + b.getMinutes() - a.getMinutes()
+  return minutesElapsed >= 60
+    ? `${hoursElapsed}시간 전`
+    : `${minutesElapsed}분 전`
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,28 @@
+export const formatDate = (inputDate: Date, now: Date): string => {
+  const today =
+    inputDate.getFullYear() === now.getFullYear() &&
+    inputDate.getMonth() === now.getMonth() &&
+    inputDate.getDate() === now.getDate()
+  const year =
+    inputDate.getFullYear() === now.getFullYear()
+      ? ''
+      : `${inputDate.getFullYear()}년`
+
+  const date = today
+    ? ''
+    : `${inputDate.getMonth() + 1}월 ${inputDate.getDate()}일`
+
+  const time = today
+    ? compareTime(inputDate, now)
+    : `${inputDate.getHours()}시 ${inputDate.getMinutes()}분`
+  return `${year} ${date} ${time}`
+}
+
+const compareTime = (a: Date, b: Date): string => {
+  const hoursCollapsed: number = b.getHours() - a.getHours()
+  const minutesCollapsed: number =
+    (b.getHours() - a.getHours()) * 60 + b.getMinutes() - a.getMinutes()
+  return minutesCollapsed >= 60
+    ? `${hoursCollapsed}시간 전`
+    : `${minutesCollapsed}분 전`
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,18 +1,18 @@
 export const formatDate = (inputDate: Date, now: Date): string => {
-  const today =
+  const today: boolean =
     inputDate.getFullYear() === now.getFullYear() &&
     inputDate.getMonth() === now.getMonth() &&
     inputDate.getDate() === now.getDate()
-  const year =
+  const year: string =
     inputDate.getFullYear() === now.getFullYear()
       ? ''
       : `${inputDate.getFullYear()}년 `
 
-  const date = today
+  const date: string = today
     ? ''
     : `${inputDate.getMonth() + 1}월 ${inputDate.getDate()}일 `
 
-  const time = today
+  const time: string = today
     ? compareTime(inputDate, now)
     : `${inputDate.getHours()}시 ${inputDate.getMinutes()}분`
   return `${year}${date}${time}`

--- a/src/utils/gps.ts
+++ b/src/utils/gps.ts
@@ -7,7 +7,10 @@ export const DEFAULT_GPS: GPS = {
   longitude: 126.976859,
 }
 
-export const getLocation = (geo: Geolocation, success: (pos: GeolocationPosition) => void) => {
+export const getLocation = (
+  geo: Geolocation,
+  success: (pos: GeolocationPosition) => void,
+) => {
   if (!geo) {
     return
   }

--- a/src/utils/gps.ts
+++ b/src/utils/gps.ts
@@ -2,7 +2,7 @@ import kaxios from '../interceptors'
 import { GPS } from '../types'
 
 // 기본값 (광화문)
-export const defaultGPS: GPS = {
+export const DEFAULT_GPS: GPS = {
   latitude: 37.575869,
   longitude: 126.976859,
 }

--- a/src/utils/useMemos.ts
+++ b/src/utils/useMemos.ts
@@ -73,6 +73,7 @@ export default function useMemos() {
     } catch (e) {
       console.error(e)
     }
+    loadMemos(userId)
     setLoading(false)
   }
 

--- a/src/utils/useMemos.ts
+++ b/src/utils/useMemos.ts
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import kaxios from 'src/interceptors'
 import { MemoInfo } from 'src/types/memo'
 import { GPS } from 'src/types'
+import { WeatherInfo } from 'src/utils/weather'
 
 export default function useMemos() {
   const [memos, setMemos] = useState<MemoInfo[]>([])
@@ -47,19 +48,20 @@ export default function useMemos() {
     setLoading(false)
   }
 
-  const addMemo = async (userId: string, category: string, text: string, gps: GPS) => {
+  const addMemo = async (
+    userId: string,
+    category: string,
+    text: string,
+    gps: GPS,
+    weather: WeatherInfo,
+  ) => {
     setLoading(true)
 
     const body: any = {
       user: userId,
       category: category,
       text: text,
-      weather: {
-        id: 0,
-        main: '날씨맑음',
-        description: '날씨맑음',
-        icon: 'b01',
-      },
+      weather,
       gps,
     }
     try {


### PR DESCRIPTION

![memo-weather](https://user-images.githubusercontent.com/52960121/122582936-af045a00-d093-11eb-984d-772f20163a51.gif)


1. 기존에 연동되고 있지 않던 날씨가 표기되도록 코드 수정하였습니다.
2. 시간이 더 예쁘게 표시되도록 하였습니다.
    * 연도: 작년까지만 표시
    * 날짜: 어제까지만 표시
    * 시간: 오늘은 XX분 전 또는 XX시간 전으로 표시, 오늘이 아닐 경우 XX시 XX분으로 표시
3. 메모 추가 시 현재 위치의 날씨를 감지해 API 요청과 같이 보내도록 수정하였습니다.