### PR TITLE
[Frontend] Header 개편

### DIFF
--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -3,12 +3,13 @@ import React, { CSSProperties, useEffect, useState } from 'react'
 import { Descriptions, Badge, Button, Input, message } from 'antd'
 import _ from 'lodash'
 import { useRouter } from 'next/dist/client/router'
-import { useRecoilState } from 'recoil'
+import { useRecoilState, useSetRecoilState } from 'recoil'
 import styled from 'styled-components'
 
 import AskAgainButton from 'src/components/AskAgain'
 import { Spinner } from 'src/components/Spinner'
 import kaxios from 'src/interceptors'
+import { subTitleState } from 'src/state/etc'
 import { meState } from 'src/state/me'
 import { FlexDiv } from 'style/div'
 
@@ -31,6 +32,8 @@ DescriptionsItem.defaultProps = {
 
 const Mypage = () => {
   const [me, setMe] = useRecoilState(meState)
+  const setSubTitle = useSetRecoilState(subTitleState)
+
   const router = useRouter()
   const [loading, setLoading] = useState<boolean>(false)
   const [onUpdateMode, setOnUpdateMode] = useState<boolean>(false)
@@ -47,6 +50,7 @@ const Mypage = () => {
       return
     }
     setUpdateValues(_.pick(me, 'name', 'nickname', 'mobile'))
+    setSubTitle('마이페이지')
   }, [me, router, onUpdateMode, loading])
 
   const onClickUpdateButton = () => {

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -12,6 +12,7 @@ import kaxios from 'src/interceptors'
 import { subTitleState } from 'src/state/etc'
 import { meState } from 'src/state/me'
 import { FlexDiv } from 'style/div'
+import { subtitles } from 'src/enum'
 
 const myLabelStyle: CSSProperties = {
   color: 'black',
@@ -50,7 +51,7 @@ const Mypage = () => {
       return
     }
     setUpdateValues(_.pick(me, 'name', 'nickname', 'mobile'))
-    setSubTitle('마이페이지')
+    setSubTitle(subtitles.mypage)
   }, [me, router, onUpdateMode, loading])
 
   const onClickUpdateButton = () => {

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -8,11 +8,11 @@ import styled from 'styled-components'
 
 import AskAgainButton from 'src/components/AskAgain'
 import { Spinner } from 'src/components/Spinner'
+import { subtitles } from 'src/enum'
 import kaxios from 'src/interceptors'
 import { subTitleState } from 'src/state/etc'
 import { meState } from 'src/state/me'
 import { FlexDiv } from 'style/div'
-import { subtitles } from 'src/enum'
 
 const myLabelStyle: CSSProperties = {
   color: 'black',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback } from 'react'
+
+import { UserOutlined } from '@ant-design/icons'
+import { SearchOutlined } from '@ant-design/icons'
+import { Row, Col, Button, Tooltip, Dropdown, Menu, Layout } from 'antd'
+import 'normalize.css'
+import 'antd/dist/antd.css'
+import { useRouter } from 'next/dist/client/router'
+import Link from 'next/link'
+import cookie from 'react-cookies'
+import { useRecoilState, useSetRecoilState } from 'recoil'
+
+import { categoriesState } from 'src/state/categories'
+import { meState } from 'src/state/me'
+
+import MenuDrawer from './MenuDrawer'
+import SubTitle from './SubTitle'
+import { FlexDiv } from 'style/div'
+
+const HeaderLayout = Layout.Header
+
+const Header = () => {
+  const [me, setMe] = useRecoilState(meState)
+  const setCategories = useSetRecoilState(categoriesState)
+  const router = useRouter()
+
+  const onClickLogout = () => {
+    cookie.remove(process.env.NEXT_PUBLIC_JWT_TOKEN_NAME!)
+    setMe(null)
+    setCategories([])
+    alert('로그아웃 성공!')
+    router.push('/')
+    return
+  }
+
+  const loggedOutUserMenu = useCallback(() => {
+    return (
+      <Button>
+        <Link href="/login">
+          <a>로그인</a>
+        </Link>
+      </Button>
+    )
+  }, [])
+
+  const loggedInUserMenu = useCallback(() => {
+    return (
+      <Dropdown
+        overlay={
+          <Menu>
+            <Menu.Item>
+              <Link href="/mypage">
+                <a>마이페이지</a>
+              </Link>
+            </Menu.Item>
+            <Menu.Item onClick={onClickLogout}>
+              <a>로그아웃</a>
+            </Menu.Item>
+            <Menu.Item>
+              <Link href="/metest">
+                <a>내정보 로드 테스트</a>
+              </Link>
+            </Menu.Item>
+          </Menu>
+        }
+        placement="bottomRight"
+        arrow>
+        <Button>
+          {<UserOutlined />}
+          {me?.nickname}
+        </Button>
+      </Dropdown>
+    )
+  }, [me])
+
+  return (
+    <HeaderLayout
+      className="site-layout-background"
+      style={{
+        padding: 0,
+        background: '#fff',
+        textAlign: 'center',
+        minHeight: '5vh',
+      }}>
+      <Row justify="space-between" align="middle" gutter={10}>
+        <Col span={2}>
+          <FlexDiv>
+            <Tooltip title="카테고리 삭제">
+              <Button type="primary" shape="circle" icon={<SearchOutlined />} />
+            </Tooltip>
+          </FlexDiv>
+        </Col>
+        <Col>{MenuDrawer()}</Col>
+        <Col span={10}>
+          <SubTitle />
+        </Col>
+        <Col>{me?._id ? loggedInUserMenu() : loggedOutUserMenu()}</Col>
+        <Col span={2}></Col>
+      </Row>
+    </HeaderLayout>
+  )
+}
+
+export default Header

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react'
 
 import { UserOutlined } from '@ant-design/icons'
-import { SearchOutlined } from '@ant-design/icons'
-import { Row, Col, Button, Tooltip, Dropdown, Menu, Layout } from 'antd'
+import { Row, Col, Button, Dropdown, Menu, Layout } from 'antd'
 import 'normalize.css'
 import 'antd/dist/antd.css'
 import { useRouter } from 'next/dist/client/router'
@@ -12,8 +11,8 @@ import { useRecoilState, useSetRecoilState } from 'recoil'
 
 import { categoriesState } from 'src/state/categories'
 import { meState } from 'src/state/me'
-import { FlexDiv } from 'style/div'
 
+import HeaderButton from './HeaderButton'
 import MenuDrawer from './MenuDrawer'
 import SubTitle from './SubTitle'
 
@@ -22,6 +21,7 @@ const HeaderLayout = Layout.Header
 const Header = () => {
   const [me, setMe] = useRecoilState(meState)
   const setCategories = useSetRecoilState(categoriesState)
+
   const router = useRouter()
 
   const onClickLogout = () => {
@@ -84,11 +84,7 @@ const Header = () => {
       }}>
       <Row justify="space-between" align="middle" gutter={10}>
         <Col span={2}>
-          <FlexDiv>
-            <Tooltip title="카테고리 삭제">
-              <Button type="primary" shape="circle" icon={<SearchOutlined />} />
-            </Tooltip>
-          </FlexDiv>
+          <HeaderButton />
         </Col>
         <Col>{MenuDrawer()}</Col>
         <Col span={10}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,78 +1,17 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
-import { UserOutlined } from '@ant-design/icons'
-import { Row, Col, Button, Dropdown, Menu, Layout } from 'antd'
+import { Row, Col, Layout } from 'antd'
 import 'normalize.css'
 import 'antd/dist/antd.css'
-import { useRouter } from 'next/dist/client/router'
-import Link from 'next/link'
-import cookie from 'react-cookies'
-import { useRecoilState, useSetRecoilState } from 'recoil'
-
-import { categoriesState } from 'src/state/categories'
-import { meState } from 'src/state/me'
 
 import HeaderButton from './HeaderButton'
 import MenuDrawer from './MenuDrawer'
 import SubTitle from './SubTitle'
+import UserMenu from './UserMenu'
 
 const HeaderLayout = Layout.Header
 
 const Header = () => {
-  const [me, setMe] = useRecoilState(meState)
-  const setCategories = useSetRecoilState(categoriesState)
-
-  const router = useRouter()
-
-  const onClickLogout = () => {
-    cookie.remove(process.env.NEXT_PUBLIC_JWT_TOKEN_NAME!)
-    setMe(null)
-    setCategories([])
-    alert('로그아웃 성공!')
-    router.push('/')
-    return
-  }
-
-  const loggedOutUserMenu = useCallback(() => {
-    return (
-      <Button>
-        <Link href="/login">
-          <a>로그인</a>
-        </Link>
-      </Button>
-    )
-  }, [])
-
-  const loggedInUserMenu = useCallback(() => {
-    return (
-      <Dropdown
-        overlay={
-          <Menu>
-            <Menu.Item>
-              <Link href="/mypage">
-                <a>마이페이지</a>
-              </Link>
-            </Menu.Item>
-            <Menu.Item onClick={onClickLogout}>
-              <a>로그아웃</a>
-            </Menu.Item>
-            <Menu.Item>
-              <Link href="/metest">
-                <a>내정보 로드 테스트</a>
-              </Link>
-            </Menu.Item>
-          </Menu>
-        }
-        placement="bottomRight"
-        arrow>
-        <Button>
-          {<UserOutlined />}
-          {me?.nickname}
-        </Button>
-      </Dropdown>
-    )
-  }, [me])
-
   return (
     <HeaderLayout
       className="site-layout-background"
@@ -83,15 +22,18 @@ const Header = () => {
         minHeight: '5vh',
       }}>
       <Row justify="space-between" align="middle" gutter={10}>
-        <Col span={2}>
+        <Col xs={3} md={0}>
+          <MenuDrawer />
+        </Col>
+        <Col xs={3} md={2}>
           <HeaderButton />
         </Col>
-        <Col>{MenuDrawer()}</Col>
-        <Col span={10}>
+        <Col xs={13} md={10}>
           <SubTitle />
         </Col>
-        <Col>{me?._id ? loggedInUserMenu() : loggedOutUserMenu()}</Col>
-        <Col span={2}></Col>
+        <Col xs={5}>
+          <UserMenu />
+        </Col>
       </Row>
     </HeaderLayout>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,10 +12,10 @@ import { useRecoilState, useSetRecoilState } from 'recoil'
 
 import { categoriesState } from 'src/state/categories'
 import { meState } from 'src/state/me'
+import { FlexDiv } from 'style/div'
 
 import MenuDrawer from './MenuDrawer'
 import SubTitle from './SubTitle'
-import { FlexDiv } from 'style/div'
 
 const HeaderLayout = Layout.Header
 

--- a/src/components/HeaderButton.tsx
+++ b/src/components/HeaderButton.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+import { SearchOutlined, DeleteOutlined, HomeOutlined } from '@ant-design/icons'
+import { Button, Tooltip } from 'antd'
+import 'normalize.css'
+import 'antd/dist/antd.css'
+import { useRecoilValue } from 'recoil'
+
+import { subtitles } from 'src/enum'
+import { categoryState } from 'src/state/category'
+import { subTitleState } from 'src/state/etc'
+import { FlexDiv } from 'style/div'
+import Link from 'next/link'
+
+const HeaderButton = () => {
+  const subtitle = useRecoilValue(subTitleState)
+  const category = useRecoilValue(categoryState)
+
+  switch (subtitle) {
+    case subtitles.main:
+      return (
+        <FlexDiv>
+          <Tooltip title="지원 예정입니다!">
+            <Button type="primary" shape="circle" icon={<SearchOutlined />} />
+          </Tooltip>
+        </FlexDiv>
+      )
+    case category?.name:
+      return (
+        <FlexDiv>
+          <Tooltip title="카테고리 삭제">
+            <Button type="primary" shape="circle" icon={<DeleteOutlined />} />
+          </Tooltip>
+        </FlexDiv>
+      )
+    default:
+      return (
+        <FlexDiv>
+          <Tooltip title="홈으로 가기">
+            <Link href="/">
+              <a>
+                <Button type="primary" shape="circle" icon={<HomeOutlined />} />
+              </a>
+            </Link>
+          </Tooltip>
+        </FlexDiv>
+      )
+  }
+  return <div></div>
+}
+
+export default HeaderButton

--- a/src/components/HeaderButton.tsx
+++ b/src/components/HeaderButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { SearchOutlined, DeleteOutlined, HomeOutlined } from '@ant-design/icons'
-import { Button, message, Tooltip } from 'antd'
+import { Button, message, Tooltip, Popconfirm } from 'antd'
 import _ from 'lodash'
 import 'normalize.css'
 import 'antd/dist/antd.css'
@@ -55,14 +55,16 @@ const HeaderButton = () => {
     case category?.name:
       return (
         <FlexDiv>
-          <Tooltip title="카테고리 삭제">
-            <Button
-              type="primary"
-              shape="circle"
-              icon={<DeleteOutlined />}
-              onClick={onClickDeleteCategory}
-            />
-          </Tooltip>
+          <Popconfirm
+            placement="bottomLeft"
+            title={'모든 데이터들이 삭제됩니다. 정말로 삭제하시겠습니까?'}
+            onConfirm={onClickDeleteCategory}
+            okText="Yes"
+            cancelText="No">
+            <Tooltip title="카테고리 삭제">
+              <Button type="primary" shape="circle" icon={<DeleteOutlined />} />
+            </Tooltip>
+          </Popconfirm>
         </FlexDiv>
       )
     default:

--- a/src/components/HeaderButton.tsx
+++ b/src/components/HeaderButton.tsx
@@ -1,20 +1,47 @@
 import React from 'react'
 
 import { SearchOutlined, DeleteOutlined, HomeOutlined } from '@ant-design/icons'
-import { Button, Tooltip } from 'antd'
+import { Button, message, Tooltip } from 'antd'
+import _ from 'lodash'
 import 'normalize.css'
 import 'antd/dist/antd.css'
-import { useRecoilValue } from 'recoil'
+import { useRouter } from 'next/dist/client/router'
+import Link from 'next/link'
+import { useRecoilState, useRecoilValue } from 'recoil'
 
 import { subtitles } from 'src/enum'
-import { categoryState } from 'src/state/category'
+import { categoriesState } from 'src/state/categories'
+import { categoryState, deleteCategory } from 'src/state/category'
 import { subTitleState } from 'src/state/etc'
 import { FlexDiv } from 'style/div'
-import Link from 'next/link'
 
 const HeaderButton = () => {
   const subtitle = useRecoilValue(subTitleState)
-  const category = useRecoilValue(categoryState)
+  const [category, setCategory] = useRecoilState(categoryState)
+  const [categories, setCategories] = useRecoilState(categoriesState)
+  const router = useRouter()
+
+  const onClickDeleteCategory = async () => {
+    if (!category || !category._id) {
+      message.error('정상 카테고리가 아닙니다!')
+      return
+    }
+    const result = await deleteCategory(category?._id)
+    if (typeof result === 'string') {
+      return message.info(result)
+    }
+    if (!result) {
+      return message.info(result)
+    }
+    message.info('카테고리 삭제 성공!')
+    setCategory(null)
+    setCategories(
+      _.filter(categories, (o) => {
+        return o._id != category._id
+      }),
+    )
+    router.push('/')
+  }
 
   switch (subtitle) {
     case subtitles.main:
@@ -29,7 +56,12 @@ const HeaderButton = () => {
       return (
         <FlexDiv>
           <Tooltip title="카테고리 삭제">
-            <Button type="primary" shape="circle" icon={<DeleteOutlined />} />
+            <Button
+              type="primary"
+              shape="circle"
+              icon={<DeleteOutlined />}
+              onClick={onClickDeleteCategory}
+            />
           </Tooltip>
         </FlexDiv>
       )
@@ -46,7 +78,6 @@ const HeaderButton = () => {
         </FlexDiv>
       )
   }
-  return <div></div>
 }
 
 export default HeaderButton

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,27 +1,21 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect } from 'react'
 
-import { UserOutlined } from '@ant-design/icons'
-import { Layout, Menu, Row, Col, Dropdown, Button, Divider } from 'antd'
+import { Layout, Divider } from 'antd'
 import 'normalize.css'
 import 'antd/dist/antd.css'
-import { useRouter } from 'next/dist/client/router'
-import Link from 'next/link'
-import cookie from 'react-cookies'
 import { useRecoilState, useSetRecoilState } from 'recoil'
 
 import { categoriesState, loadCategories } from 'src/state/categories'
 
 import { loadMe, meState } from '../state/me'
-import MenuDrawer from './MenuDrawer'
+import Header from './Header'
 import MenuSider from './MenuSider'
-import SubTitle from './SubTitle'
 
-const { Header, Footer, Content } = Layout
+const { Footer, Content } = Layout
 
 const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
   const [me, setMe] = useRecoilState(meState)
   const setCategories = useSetRecoilState(categoriesState)
-  const router = useRouter()
 
   const loadMyInfo = async () => {
     const meInfo = await loadMe()
@@ -40,78 +34,12 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
     loadMyInfo()
   }, [me, setMe])
 
-  const onClickLogout = () => {
-    cookie.remove(process.env.NEXT_PUBLIC_JWT_TOKEN_NAME!)
-    setMe(null)
-    setCategories([])
-    alert('로그아웃 성공!')
-    router.push('/')
-    return
-  }
-
-  const loggedOutUserMenu = useCallback(() => {
-    return (
-      <Button>
-        <Link href="/login">
-          <a>로그인</a>
-        </Link>
-      </Button>
-    )
-  }, [])
-
-  const loggedInUserMenu = useCallback(() => {
-    return (
-      <Dropdown
-        overlay={
-          <Menu>
-            <Menu.Item>
-              <Link href="/mypage">
-                <a>마이페이지</a>
-              </Link>
-            </Menu.Item>
-            <Menu.Item onClick={onClickLogout}>
-              <a>로그아웃</a>
-            </Menu.Item>
-            <Menu.Item>
-              <Link href="/metest">
-                <a>내정보 로드 테스트</a>
-              </Link>
-            </Menu.Item>
-          </Menu>
-        }
-        placement="bottomRight"
-        arrow>
-        <Button>
-          {<UserOutlined />}
-          {me?.nickname}
-        </Button>
-      </Dropdown>
-    )
-  }, [me])
-
   return (
     <>
       <Layout>
         {MenuSider()}
         <Layout className="site-layout">
-          <Header
-            className="site-layout-background"
-            style={{
-              padding: 0,
-              background: '#fff',
-              textAlign: 'center',
-              minHeight: '5vh',
-            }}>
-            <Row justify="space-between" align="middle" gutter={10}>
-              <Col span={1}></Col>
-              <Col>{MenuDrawer()}</Col>
-              <Col span={10}>
-                <SubTitle />
-              </Col>
-              <Col>{me?._id ? loggedInUserMenu() : loggedOutUserMenu()}</Col>
-              <Col span={1}></Col>
-            </Row>
-          </Header>
+          <Header />
           <Content
             style={{
               margin: '24px 16px 0',

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useCallback } from 'react'
 
 import { UserOutlined } from '@ant-design/icons'
 import { Layout, Menu, Row, Col, Dropdown, Button, Divider } from 'antd'
@@ -14,6 +14,7 @@ import { categoriesState, loadCategories } from 'src/state/categories'
 import { loadMe, meState } from '../state/me'
 import MenuDrawer from './MenuDrawer'
 import MenuSider from './MenuSider'
+import SubTitle from './SubTitle'
 
 const { Header, Footer, Content } = Layout
 
@@ -48,7 +49,7 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
     return
   }
 
-  const loggedOutUserMenu = () => {
+  const loggedOutUserMenu = useCallback(() => {
     return (
       <Button>
         <Link href="/login">
@@ -56,9 +57,9 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
         </Link>
       </Button>
     )
-  }
+  }, [])
 
-  const loggedInUserMenu = () => {
+  const loggedInUserMenu = useCallback(() => {
     return (
       <Dropdown
         overlay={
@@ -86,7 +87,7 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
         </Button>
       </Dropdown>
     )
-  }
+  }, [me])
 
   return (
     <>
@@ -104,7 +105,9 @@ const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
             <Row justify="space-between" align="middle" gutter={10}>
               <Col span={1}></Col>
               <Col>{MenuDrawer()}</Col>
-              <Col span={10}></Col>
+              <Col span={10}>
+                <SubTitle />
+              </Col>
               <Col>{me?._id ? loggedInUserMenu() : loggedOutUserMenu()}</Col>
               <Col span={1}></Col>
             </Row>

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -23,7 +23,7 @@ const MenuDrawer = () => {
   if (useWindowSize()[0] <= xs)
     return (
       <>
-        <Button type="primary" onClick={showDrawer}>
+        <Button type="primary" onClick={showDrawer} size="small">
           <MenuOutlined />
         </Button>
         <Drawer

--- a/src/components/MenuLayout.tsx
+++ b/src/components/MenuLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useCallback } from 'react'
 
 import {
   PlusCircleOutlined,
@@ -17,12 +18,12 @@ import {
   categoriesState,
   categoryAddAvailState,
 } from 'src/state/categories'
-import { menuCollapsedState, subTitleState } from 'src/state/etc'
+import { categoryState } from 'src/state/category'
+import { menuCollapsedState } from 'src/state/etc'
 import { meState } from 'src/state/me'
 import { CategoryInfo } from 'src/types/category'
 import { UserInfo } from 'src/types/user'
 import { FlexDiv } from 'style/div'
-import { useCallback } from 'react'
 
 const MENU_LABEL_COLOR = '#fff5eb'
 
@@ -59,11 +60,12 @@ const CategoryTitleLabel = ({
 const MenuLayout = () => {
   const me = useRecoilValue(meState)
   const [categories, setCategories] = useRecoilState(categoriesState)
+  const setCategory = useSetRecoilState(categoryState)
   const menuCollapsed = useRecoilValue(menuCollapsedState)
+  const categoryAddAvail = useRecoilValue(categoryAddAvailState)
+
   const [isModalVisible, setIsModalVisible] = useState(false)
   const [categoryValue, setCategoryValue] = useState('')
-  const categoryAddAvail = useRecoilValue(categoryAddAvailState)
-  const setSubTitle = useSetRecoilState(subTitleState)
 
   const showModal = useCallback(() => {
     setIsModalVisible(true)
@@ -88,6 +90,14 @@ const MenuLayout = () => {
   const handleCancel = useCallback(() => {
     setIsModalVisible(false)
   }, [isModalVisible])
+
+  const onClickCategory = useCallback(
+    (category: CategoryInfo) => () => {
+      setCategory(category)
+      setCategoryValue(category.name)
+    },
+    [categories],
+  )
 
   return (
     <>
@@ -114,9 +124,7 @@ const MenuLayout = () => {
             <Menu.Item
               key={`menu_${category._id}`}
               icon={<FolderFilled />}
-              onClick={() => {
-                setSubTitle(category.name)
-              }}>
+              onClick={onClickCategory(category)}>
               <Link href={`/?categoryId=${category._id}`}>
                 <a>{category.name}</a>
               </Link>

--- a/src/components/MenuLayout.tsx
+++ b/src/components/MenuLayout.tsx
@@ -10,18 +10,19 @@ import {
 import { Divider, Input, Menu, message, Typography } from 'antd'
 import Modal from 'antd/lib/modal/Modal'
 import Link from 'next/link'
-import { useRecoilState, useRecoilValue } from 'recoil'
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
 
 import {
   addCategories,
   categoriesState,
   categoryAddAvailState,
 } from 'src/state/categories'
-import { menuCollapsedState } from 'src/state/etc'
+import { menuCollapsedState, subTitleState } from 'src/state/etc'
 import { meState } from 'src/state/me'
 import { CategoryInfo } from 'src/types/category'
 import { UserInfo } from 'src/types/user'
 import { FlexDiv } from 'style/div'
+import { useCallback } from 'react'
 
 const MENU_LABEL_COLOR = '#fff5eb'
 
@@ -62,13 +63,13 @@ const MenuLayout = () => {
   const [isModalVisible, setIsModalVisible] = useState(false)
   const [categoryValue, setCategoryValue] = useState('')
   const categoryAddAvail = useRecoilValue(categoryAddAvailState)
+  const setSubTitle = useSetRecoilState(subTitleState)
 
-  console.log(menuCollapsed)
-  const showModal = () => {
+  const showModal = useCallback(() => {
     setIsModalVisible(true)
-  }
+  }, [isModalVisible])
 
-  const handleOk = async () => {
+  const handleOk = useCallback(async () => {
     setIsModalVisible(false)
     if (!me || !me._id) {
       return message.error('로그인이 필요합니다!')
@@ -82,11 +83,12 @@ const MenuLayout = () => {
     }
     setCategories([newCategory, ...categories])
     message.info('카테고리 추가 성공!')
-  }
+  }, [categories, isModalVisible, me, me?._id, categoryAddAvail, categoryValue])
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     setIsModalVisible(false)
-  }
+  }, [isModalVisible])
+
   return (
     <>
       <Modal
@@ -109,7 +111,12 @@ const MenuLayout = () => {
       <Menu style={{ zIndex: 5 }} mode="inline" theme="dark">
         {categories.map((category: CategoryInfo) => {
           return (
-            <Menu.Item key={`menu_${category._id}`} icon={<FolderFilled />}>
+            <Menu.Item
+              key={`menu_${category._id}`}
+              icon={<FolderFilled />}
+              onClick={() => {
+                setSubTitle(category.name)
+              }}>
               <Link href={`/?categoryId=${category._id}`}>
                 <a>{category.name}</a>
               </Link>

--- a/src/components/SubTitle.tsx
+++ b/src/components/SubTitle.tsx
@@ -1,0 +1,21 @@
+import { Typography } from 'antd'
+import { useRecoilValue } from 'recoil'
+import styled from 'styled-components'
+
+import { subTitleState } from 'src/state/etc'
+import { FlexDiv } from 'style/div'
+
+export const SubTitleH1 = styled(Typography.Title)`
+  margin-bottom: 0;
+`
+
+const SubTitle = () => {
+  const text = useRecoilValue(subTitleState)
+  return (
+    <FlexDiv>
+      <SubTitleH1>{text}</SubTitleH1>
+    </FlexDiv>
+  )
+}
+
+export default SubTitle

--- a/src/components/SubTitle.tsx
+++ b/src/components/SubTitle.tsx
@@ -1,19 +1,16 @@
 import { Typography } from 'antd'
 import { useRecoilValue } from 'recoil'
-import styled from 'styled-components'
 
 import { subTitleState } from 'src/state/etc'
 import { FlexDiv } from 'style/div'
-
-export const SubTitleH1 = styled(Typography.Title)`
-  margin-bottom: 0;
-`
 
 const SubTitle = () => {
   const text = useRecoilValue(subTitleState)
   return (
     <FlexDiv>
-      <SubTitleH1>{text}</SubTitleH1>
+      <Typography.Title level={2} style={{ marginBottom: 0 }}>
+        {text}
+      </Typography.Title>
     </FlexDiv>
   )
 }

--- a/src/components/SubTitle.tsx
+++ b/src/components/SubTitle.tsx
@@ -1,17 +1,32 @@
-import { Typography } from 'antd'
 import { useRecoilValue } from 'recoil'
+import styled from 'styled-components'
 
 import { subTitleState } from 'src/state/etc'
 import { FlexDiv } from 'style/div'
 
+const SubTitleDiv = styled(FlexDiv)`
+  overflow: hidden;
+`
+const SubTitleH = styled.h1`
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 20px;
+  overflow: auto;
+  white-space: nowrap;
+
+  @media (min-width: 768px) {
+    font-weight: 600;
+    font-size: 30px;
+    line-height: 1.35;
+  }
+`
+
 const SubTitle = () => {
   const text = useRecoilValue(subTitleState)
   return (
-    <FlexDiv>
-      <Typography.Title level={2} style={{ marginBottom: 0 }}>
-        {text}
-      </Typography.Title>
-    </FlexDiv>
+    <SubTitleDiv>
+      <SubTitleH>{text}</SubTitleH>
+    </SubTitleDiv>
   )
 }
 

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback } from 'react'
+
+import { UserOutlined } from '@ant-design/icons'
+import { Button, Dropdown, Menu, Typography } from 'antd'
+import 'normalize.css'
+import 'antd/dist/antd.css'
+import { useRouter } from 'next/dist/client/router'
+import Link from 'next/link'
+import cookie from 'react-cookies'
+import { useRecoilState } from 'recoil'
+
+import { categoriesState } from 'src/state/categories'
+import { meState } from 'src/state/me'
+import { useWindowSize, sm } from 'src/utils/size'
+import { FlexDiv } from 'style/div'
+
+const UserMenu = () => {
+  const [me, setMe] = useRecoilState(meState)
+  const [categories, setCategories] = useRecoilState(categoriesState)
+  const router = useRouter()
+  const windowSize = useWindowSize()[0]
+
+  const onClickLogout = useCallback(() => {
+    cookie.remove(process.env.NEXT_PUBLIC_JWT_TOKEN_NAME!)
+    setMe(null)
+    setCategories([])
+    alert('로그아웃 성공!')
+    router.push('/')
+    return
+  }, [me, categories, router])
+
+  return me ? (
+    <Dropdown
+      overlay={
+        <Menu>
+          <Menu.Item>
+            <Link href="/mypage">
+              <a>마이페이지</a>
+            </Link>
+          </Menu.Item>
+          <Menu.Item onClick={onClickLogout}>
+            <a>로그아웃</a>
+          </Menu.Item>
+          <Menu.Item>
+            <Link href="/metest">
+              <a>내정보 로드 테스트</a>
+            </Link>
+          </Menu.Item>
+        </Menu>
+      }
+      placement="bottomRight"
+      arrow>
+      <Button>
+        <FlexDiv justify="space-between" width="auto">
+          {<UserOutlined />}
+          {windowSize >= sm ? (
+            <Typography style={{ marginLeft: '0.5em' }}>
+              {me?.nickname}
+            </Typography>
+          ) : (
+            ''
+          )}
+        </FlexDiv>
+      </Button>
+    </Dropdown>
+  ) : (
+    <Button>
+      <Link href="/login">
+        <a>로그인</a>
+      </Link>
+    </Button>
+  )
+}
+
+export default UserMenu

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -27,7 +27,7 @@ import Link from 'next/link'
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { subtitles } from 'src/enum'
-import { categorySubtitleState } from 'src/state/category'
+import { categorySubTitleState } from 'src/state/category'
 import { subTitleState } from 'src/state/etc'
 import { sm, md, useWindowSize } from 'src/utils/size'
 import useMemos from 'src/utils/useMemos'
@@ -50,7 +50,7 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
   } = useMemos()
   const [me] = useRecoilState(meState)
   const setSubTitle = useSetRecoilState(subTitleState)
-  const categorySubTitle = useRecoilValue(categorySubtitleState)
+  const categorySubTitle = useRecoilValue(categorySubTitleState)
 
   useEffect(() => {
     if (!me || !me._id) {
@@ -64,7 +64,7 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
     }
     loadMemos(me._id!)
     setSubTitle(subtitles.main)
-  }, [me, me?._id, categoryId, categorySubTitle, categorySubtitleState])
+  }, [me, me?._id, categoryId, categorySubTitle, categorySubTitleState])
 
   if (loading) {
     return <Spinner></Spinner>

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -33,6 +33,7 @@ import { categoriesState } from '../state/categories'
 import { meState } from '../state/me'
 import { CategoryInfo } from '../types/category'
 import { MemoInfo } from '../types/memo'
+import { subTitleState } from 'src/state/etc'
 
 function useMemos() {
   const [memos, setMemos] = useState<MemoInfo[]>([])
@@ -152,12 +153,10 @@ function useMemos() {
 export function Main() {
   const { memos, loadMemos, addMemo, deleteMemo, sortMemos } = useMemos()
   const [me] = useRecoilState(meState)
+  const [subTitle, setSubTitle] = useRecoilState(subTitleState)
 
   useEffect(() => {
-    if (!me) {
-      return
-    }
-    if (!me._id) {
+    if (!me || !me._id) {
       return
     }
     loadMemos(me._id!)

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -27,6 +27,7 @@ import Link from 'next/link'
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { subtitles } from 'src/enum'
+import { categorySubtitleState } from 'src/state/category'
 import { subTitleState } from 'src/state/etc'
 import { sm, md, useWindowSize } from 'src/utils/size'
 import useMemos from 'src/utils/useMemos'
@@ -36,7 +37,6 @@ import { meState } from '../state/me'
 import { CategoryInfo } from '../types/category'
 import { MemoInfo } from '../types/memo'
 import { Spinner } from './Spinner'
-import { categorySubtitleState } from 'src/state/category'
 
 export function Main({ categoryId }: { categoryId?: string | undefined }) {
   const {

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -26,6 +26,7 @@ import {
 import Link from 'next/link'
 import { useRecoilState, useSetRecoilState } from 'recoil'
 
+import { subtitles } from 'src/enum'
 import { subTitleState } from 'src/state/etc'
 import { sm, md, useWindowSize } from 'src/utils/size'
 import useMemos from 'src/utils/useMemos'
@@ -59,7 +60,7 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
       return
     }
     loadMemos(me._id!)
-    setSubTitle('전체 메모')
+    setSubTitle(subtitles.main)
   }, [me, me?._id, categoryId])
 
   if (loading) {

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -24,7 +24,7 @@ import {
   Select,
 } from 'antd'
 import Link from 'next/link'
-import { useRecoilState } from 'recoil'
+import { useRecoilState, useSetRecoilState } from 'recoil'
 
 import { subTitleState } from 'src/state/etc'
 import { sm, md, useWindowSize } from 'src/utils/size'
@@ -47,10 +47,11 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
     loading,
   } = useMemos()
   const [me] = useRecoilState(meState)
-  const [subTitle, setSubTitle] = useRecoilState(subTitleState)
+  const setSubTitle = useSetRecoilState(subTitleState)
 
   useEffect(() => {
     if (!me || !me._id) {
+      setSubTitle('')
       return
     }
     if (categoryId) {
@@ -58,6 +59,7 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
       return
     }
     loadMemos(me._id!)
+    setSubTitle('전체 메모')
   }, [me, me?._id, categoryId])
 
   if (loading) {

--- a/src/components/main.tsx
+++ b/src/components/main.tsx
@@ -24,7 +24,7 @@ import {
   Select,
 } from 'antd'
 import Link from 'next/link'
-import { useRecoilState, useSetRecoilState } from 'recoil'
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { subtitles } from 'src/enum'
 import { subTitleState } from 'src/state/etc'
@@ -36,6 +36,7 @@ import { meState } from '../state/me'
 import { CategoryInfo } from '../types/category'
 import { MemoInfo } from '../types/memo'
 import { Spinner } from './Spinner'
+import { categorySubtitleState } from 'src/state/category'
 
 export function Main({ categoryId }: { categoryId?: string | undefined }) {
   const {
@@ -49,6 +50,7 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
   } = useMemos()
   const [me] = useRecoilState(meState)
   const setSubTitle = useSetRecoilState(subTitleState)
+  const categorySubTitle = useRecoilValue(categorySubtitleState)
 
   useEffect(() => {
     if (!me || !me._id) {
@@ -57,11 +59,12 @@ export function Main({ categoryId }: { categoryId?: string | undefined }) {
     }
     if (categoryId) {
       loadCategoryMemos(categoryId)
+      setSubTitle(categorySubTitle)
       return
     }
     loadMemos(me._id!)
     setSubTitle(subtitles.main)
-  }, [me, me?._id, categoryId])
+  }, [me, me?._id, categoryId, categorySubTitle, categorySubtitleState])
 
   if (loading) {
     return <Spinner></Spinner>

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -1,1 +1,7 @@
 export const NAVER_API_URL = 'https://openapi.naver.com/v1/nid/me'
+
+export const subtitles = {
+  main: '전체 메모',
+  mypage: '마이페이지',
+  etc: '기타',
+}

--- a/src/state/categories.ts
+++ b/src/state/categories.ts
@@ -58,19 +58,3 @@ export const addCategories = async (userId: string, name: string) => {
     return false
   }
 }
-
-export const deleteCategories = async (categoryId: string) => {
-  try {
-    const res = await kaxios({
-      url: `/category/${categoryId}`,
-      method: 'delete',
-    })
-    return res.data
-  } catch (e) {
-    console.error(e)
-    if (e.response?.data?.alertText) {
-      return e.response?.data?.alertText
-    }
-    return false
-  }
-}

--- a/src/state/category.ts
+++ b/src/state/category.ts
@@ -1,0 +1,19 @@
+import { atom, selector } from 'recoil'
+
+import { CategoryInfo } from 'src/types/category'
+
+export const categoryState = atom<CategoryInfo | null>({
+  key: 'categoryState',
+  default: null,
+})
+
+export const categorySubtitleState = selector<string>({
+  key: 'categorySubtitleState',
+  get: ({ get }) => {
+    const categoryInstance = get(categoryState)
+    if (categoryInstance?.name) {
+      return categoryInstance?.name
+    }
+    return '전체 메모'
+  },
+})

--- a/src/state/category.ts
+++ b/src/state/category.ts
@@ -1,5 +1,6 @@
 import { atom, selector } from 'recoil'
 
+import kaxios from 'src/interceptors'
 import { CategoryInfo } from 'src/types/category'
 
 export const categoryState = atom<CategoryInfo | null>({
@@ -17,3 +18,19 @@ export const categorySubtitleState = selector<string>({
     return '전체 메모'
   },
 })
+
+export const deleteCategory = async (categoryId: string) => {
+  try {
+    const res = await kaxios({
+      url: `/category/${categoryId}`,
+      method: 'delete',
+    })
+    return res.data
+  } catch (e) {
+    console.error(e)
+    if (e.response?.data?.alertText) {
+      return e.response?.data?.alertText
+    }
+    return false
+  }
+}

--- a/src/state/category.ts
+++ b/src/state/category.ts
@@ -8,8 +8,8 @@ export const categoryState = atom<CategoryInfo | null>({
   default: null,
 })
 
-export const categorySubtitleState = selector<string>({
-  key: 'categorySubtitleState',
+export const categorySubTitleState = selector<string>({
+  key: 'categorySubTitleState',
   get: ({ get }) => {
     const categoryInstance = get(categoryState)
     if (categoryInstance?.name) {

--- a/src/state/etc.ts
+++ b/src/state/etc.ts
@@ -4,3 +4,8 @@ export const menuCollapsedState = atom<boolean>({
   key: 'menuCollapsed',
   default: false,
 })
+
+export const subTitleState = atom<string>({
+  key: 'subTitleState',
+  default: '',
+})


### PR DESCRIPTION
### PR 요약

Header (맨 위에 흰 부분) 를 재구성하고, Subtitle과 기능 버튼을 추가하였습니다.


#### 1. header용 버튼 추가
![0619pr](https://user-images.githubusercontent.com/28820058/122589557-5d5fcd80-d09b-11eb-92f9-33f63f1978a0.gif)

UX 관점에서 편리한 기능을 제공하는 header 용 버튼을 추가하였습니다.

페이지 별로 버튼 모양 및 기능이 변경됩니다.

- 홈 : 검색 (아직 기능은 구현 안됨, Future task)
- 카테고리 별 메모 : 카테고리 삭제
- 기타 : 홈으로 이동


#### 2. subtitle 추가

![image](https://user-images.githubusercontent.com/28820058/122588620-4371bb00-d09a-11eb-8b4a-e697c7912987.png)

- 선택된 category , 혹은 현재 페이지에 따라 변경
- `subTitleState` 가 현재 subTitle의 텍스트를 담고 있음

#### 3. 카테고리 state 추가

유저 입장에서 현재 선택한 카테고리가 무엇인지 의미하는 카테고리 state를 추가하였습니다.
선택된 카테고리를 전역 state로 관리해야, 카테고리 삭제나 카테고리에 따른 subtitle 설정이 쉽기 때문입니다.
- `/src/state/category` 의 `categoryState` , `categorySubtitleState`
- `subtitleState` 추가

#### 4. 카테고리 삭제

카테고리 삭제기능이 구현이 안되어있어 새롭게 구현했습니다.
- header용 버튼을 이용해서 삭제 가능

#### 5. 기타
- 레이아웃 모듈화
- 버그 수정

#### 해야될 것들

- 모바일 반응성 구현

혹시 버그 발견하면 말씀해주세요!