### PR TITLE
[Frontend] 메모 추가기능, 메모 추가 버튼 변경

### DIFF
--- a/pages/api/api.yaml
+++ b/pages/api/api.yaml
@@ -1,8 +1,9 @@
 swagger: '2.0'
 info:
-  description: 'Kramo 의 API 문서입니다. NextJS 를 기반으로 돌아가고, 작성 중에 있습니다.'
+  description: 'Kramo 의 API 문서입니다.'
   version: '1.0.0'
   title: 'Kramo'
+  termsOfService: 'https://github.com/Memo8-KoreaUniv/kramo/wiki/'
   contact:
     email: 'ddrrpg@naver.com'
   license:
@@ -21,19 +22,9 @@ tags:
     description: '메모 도메인'
   - name: 'history'
     description: '히스토리 도메인'
-    # externalDocs:
-    #   description: 'Github'
-    #   url: 'https://github.com/Memo8-KoreaUniv/kramo'
 schemes:
   - 'https'
 securityDefinitions:
-  # petstore_auth:
-  #   type: 'oauth2'
-  #   authorizationUrl: 'http://petstore.swagger.io/oauth/dialog'
-  #   flow: 'implicit'
-  #   scopes:
-  #     write:pets: 'modify pets in your account'
-  #     read:pets: 'read your pets'
   ormakkc:
     type: apiKey
     name: Cookie
@@ -287,7 +278,7 @@ paths:
             properties:
               pin:
                 type: array
-                items: 
+                items:
                   properties:
                     _id:
                       type: boolean

--- a/pages/editor.tsx
+++ b/pages/editor.tsx
@@ -66,7 +66,9 @@ const Editor = ({
 
   useEffect(() => {
     if (firstCreation) {
-      setHistories([INITIAL_HISTORY])
+      setHistories([
+        { ...INITIAL_HISTORY, createdAt: new Date().toUTCString() },
+      ])
       return
     }
     setHistories(initialHistories)

--- a/pages/editor.tsx
+++ b/pages/editor.tsx
@@ -9,6 +9,7 @@ import dynamic from 'next/dynamic'
 import { useRecoilState, useRecoilValue } from 'recoil'
 
 import HistoryTimeline from 'src/components/memo/HistoryTimeline'
+import { Spinner } from 'src/components/Spinner'
 import {
   categoriesState,
   isCategoryLoadingTriedState,
@@ -47,6 +48,7 @@ const Editor = ({
   firstCreation: boolean
 }): JSX.Element => {
   const [text, setText] = useState('')
+  const [loading, setLoading] = useState<boolean>(false)
   const [value, setValue] = useState('기존 카테고리가 유지됩니다.')
   const [selectedCategoryId, setSelectedCategoryId] = useState<string>('')
   const me = useRecoilValue(meState)
@@ -111,7 +113,7 @@ const Editor = ({
     if (!innerText) {
       return message.error('아무것도 입력되지 않았습니다!')
     }
-
+    setLoading(true)
     getLocation(navigator.geolocation, (pos: GeolocationPosition) => {
       const GPS = {
         latitude: pos.coords.latitude,
@@ -139,6 +141,7 @@ const Editor = ({
             GPS,
             currentWeather,
           )
+          setLoading(false)
           setHistories([newMemo])
           setHistoryIndex(0)
           router.push(`/editor?memoId=${newMemo.memo._id}`, undefined, {
@@ -146,12 +149,15 @@ const Editor = ({
           })
         } else {
           newMemo = await addHistory(newHistory)
+          setLoading(false)
           if (newMemo) {
             setHistories([newMemo, ...histories])
             setHistoryIndex(0)
-            return message.info('저장 성공!')
+            message.info('저장 성공!')
+            return
           }
-          return message.error('저장이 실패하였습니다.')
+          message.error('저장이 실패하였습니다.')
+          return
         }
       })
     })
@@ -191,12 +197,22 @@ const Editor = ({
         </Col>
         <Col xs={12} md={6}>
           <FlexDiv direction="row" justify="flex-end">
-            <Button danger onClick={onClickCancel}>
-              취소
+            <Button
+              type="primary"
+              danger
+              onClick={onClickCancel}
+              style={{ marginRight: '3px' }}>
+              뒤로 가기
             </Button>
-            <Button type="primary" onClick={onClickSave}>
-              저장
-            </Button>
+            {loading ? (
+              <Button type="primary">
+                <Spinner />
+              </Button>
+            ) : (
+              <Button type="primary" onClick={onClickSave}>
+                저장
+              </Button>
+            )}
           </FlexDiv>
         </Col>
       </Row>

--- a/pages/editor.tsx
+++ b/pages/editor.tsx
@@ -1,14 +1,19 @@
 import React, { LegacyRef, useEffect, useState } from 'react'
 
 import { Editor as ToastUIEditor } from '@toast-ui/react-editor'
-import { message } from 'antd'
+import { message, Select } from 'antd'
 import { Button, Row, Col } from 'antd'
 import { NextPageContext } from 'next'
 import { useRouter } from 'next/dist/client/router'
 import dynamic from 'next/dynamic'
-import { useRecoilState } from 'recoil'
+import { useRecoilState, useRecoilValue } from 'recoil'
 
 import HistoryTimeline from 'src/components/memo/HistoryTimeline'
+import {
+  categoriesState,
+  isCategoryLoadingTriedState,
+} from 'src/state/categories'
+import { categoryState } from 'src/state/category'
 import {
   historiesState,
   historyIndexState,
@@ -16,27 +21,83 @@ import {
   addHistory,
   AddHistoryProps,
 } from 'src/state/history'
+import { meState } from 'src/state/me'
+import { CategoryInfo } from 'src/types/category'
 import { HistoryInfo } from 'src/types/history'
+import { getLocation } from 'src/utils/gps'
+import useMemos from 'src/utils/useMemos'
+import { getNowWeatherByGeo } from 'src/utils/weather'
 import { FlexDiv } from 'style/div'
+const { Option } = Select
 
 const PostEditor = dynamic(() => import('src/components/ToastEditor'), {
   ssr: false,
 })
 
+const INITIAL_HISTORY: any = {
+  text: '첫 메모입니다!',
+  createdAt: new Date().toUTCString(),
+}
+
 const Editor = ({
   initialHistories,
+  firstCreation,
 }: {
   initialHistories: HistoryInfo[]
+  firstCreation: boolean
 }): JSX.Element => {
-  const router = useRouter()
   const [text, setText] = useState('')
-  const [historyIndex, setHistoryIndex] = useRecoilState(historyIndexState)
+  const [value, setValue] = useState('기존 카테고리가 유지됩니다.')
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string>('')
+  const me = useRecoilValue(meState)
+  const categories = useRecoilValue(categoriesState)
+  const isCategoryLoadingTried = useRecoilValue(isCategoryLoadingTriedState)
+  const [category, setCategory] = useRecoilState(categoryState)
   const [histories, setHistories] = useRecoilState(historiesState)
+  const [historyIndex, setHistoryIndex] = useRecoilState(historyIndexState)
+
   const editorRef: LegacyRef<ToastUIEditor> = React.createRef()
+  const router = useRouter()
+  const { addMemo } = useMemos()
+
+  const categoryPairs: { [key: string]: string } = {}
 
   useEffect(() => {
+    if (firstCreation) {
+      setHistories([INITIAL_HISTORY])
+      return
+    }
     setHistories(initialHistories)
   }, [])
+
+  useEffect(() => {
+    if (isCategoryLoadingTried && !me) {
+      alert('로그인이 필요합니다!')
+      router.push('/')
+      return
+    }
+  }, [me, isCategoryLoadingTried])
+
+  useEffect(() => {
+    if (
+      isCategoryLoadingTried &&
+      (categories === [] || categories.length === 0)
+    ) {
+      alert('카테고리를 먼저 생성해주세요!')
+      router.push('/')
+      return
+    }
+    if (categories && categories.length !== 0) {
+      setSelectedCategoryId(categories[0]._id)
+      if (!category) {
+        setCategory(categories[0])
+        setSelectedCategoryId(categories[0]._id)
+      }
+    }
+    if (category) {
+      setValue(category.name)
+    }
+  }, [categories, category, isCategoryLoadingTried])
 
   useEffect(() => {
     const changedText =
@@ -45,39 +106,95 @@ const Editor = ({
     editorRef.current?.getInstance().setHtml(changedText)
   }, [histories, historyIndex])
 
-  const addMemo = async () => {
+  const onClickSave = async () => {
     const innerText = editorRef.current?.getInstance().getHtml()
-    if (innerText === undefined) {
+    if (!innerText) {
       return message.error('아무것도 입력되지 않았습니다!')
     }
 
-    const newHistory: AddHistoryProps = { ...histories[0], text: innerText }
-    delete newHistory._id
-    if (newHistory.createdAt) delete newHistory.createdAt
-
-    const newMemo = await addHistory(newHistory)
-    if (newMemo) {
-      setHistories([newMemo, ...histories])
-      setHistoryIndex(0)
-      return message.info('저장 성공!')
-    }
-    return message.error('저장이 실패하였습니다.')
+    getLocation(navigator.geolocation, (pos: GeolocationPosition) => {
+      const GPS = {
+        latitude: pos.coords.latitude,
+        longitude: pos.coords.longitude,
+      }
+      getNowWeatherByGeo(
+        GPS.latitude,
+        GPS.longitude,
+        process.env.NEXT_PUBLIC_WEATHER_API_KEY!,
+      ).then(async (currentWeather) => {
+        const newHistory: AddHistoryProps = {
+          ...histories[0],
+          gps: GPS,
+          text: innerText,
+          weather: currentWeather,
+        }
+        delete newHistory._id
+        if (newHistory.createdAt) delete newHistory.createdAt
+        let newMemo
+        if (firstCreation) {
+          newMemo = await addMemo(
+            me!._id,
+            selectedCategoryId,
+            innerText,
+            GPS,
+            currentWeather,
+          )
+          setHistories([newMemo])
+          setHistoryIndex(0)
+          router.push(`/editor?memoId=${newMemo.memo._id}`, undefined, {
+            shallow: false,
+          })
+        } else {
+          newMemo = await addHistory(newHistory)
+          if (newMemo) {
+            setHistories([newMemo, ...histories])
+            setHistoryIndex(0)
+            return message.info('저장 성공!')
+          }
+          return message.error('저장이 실패하였습니다.')
+        }
+      })
+    })
   }
 
   const onClickCancel = () => {
     router.back()
   }
 
+  const onChangeSelector = (name: any) => {
+    setValue(name)
+    setSelectedCategoryId(categoryPairs[name])
+    return
+  }
+
   return (
     <>
       <Row style={{ marginBottom: '0.5rem' }}>
-        <Col xs={24} md={17}></Col>
-        <Col xs={24} md={6}>
+        <Col xs={12} md={17}>
+          <Select
+            style={{ width: '100%' }}
+            defaultValue={
+              category ? category.name : '기존 카테고리가 유지됩니다.'
+            }
+            value={value}
+            disabled={!firstCreation}
+            onChange={onChangeSelector}>
+            {categories.map((cate: CategoryInfo) => {
+              categoryPairs[cate.name] = cate._id
+              return (
+                <Option key={`CategorySelector_${cate._id}`} value={cate.name}>
+                  {cate.name}
+                </Option>
+              )
+            })}
+          </Select>
+        </Col>
+        <Col xs={12} md={6}>
           <FlexDiv direction="row" justify="flex-end">
             <Button danger onClick={onClickCancel}>
               취소
             </Button>
-            <Button type="primary" onClick={addMemo}>
+            <Button type="primary" onClick={onClickSave}>
               저장
             </Button>
           </FlexDiv>
@@ -102,17 +219,18 @@ export async function getServerSideProps(ctx: NextPageContext) {
 
   const loadMemo = async () => {
     if (!memoId || typeof memoId === 'object') {
-      return [{ text: '에러가 발생했습니다! 이전 페이지로 돌아가주세요' }]
+      return [[{ text: '첫 메모입니다!' }], true]
     }
     const historyInfo = await loadHistories(memoId)
-    return historyInfo
+    return [historyInfo, false]
   }
 
-  const initialHistories = await loadMemo()
+  const [initialHistories, firstCreation] = await loadMemo()
 
   return {
     props: {
       initialHistories,
+      firstCreation,
     },
   }
 }

--- a/src/components/AddCardButton.tsx
+++ b/src/components/AddCardButton.tsx
@@ -27,7 +27,7 @@ const FlexibleAddCard = styled.div`
   vertical-align: middle;
   opacity: 0.5;
   cursor: pointer;
-  background-color: #ffed99;
+  background-color: #a2dbfa;
   border: 0px solid #686d76;
 
   @media (min-width: ${sm}px) {

--- a/src/components/AddCardButton.tsx
+++ b/src/components/AddCardButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import { EnvironmentOutlined, PlusOutlined } from '@ant-design/icons'
-import { Image, Card, Col, Modal, Row, Input, Select } from 'antd'
+import { Image, Col, Modal, Row, Input, Select, Typography } from 'antd'
 import { useRecoilState } from 'recoil'
 import styled from 'styled-components'
 
@@ -18,15 +18,21 @@ import {
   getNowWeatherByGeo,
   EMPTY_WEATHER,
 } from 'src/utils/weather'
+import { FlexDiv } from 'style/div'
 
-const FlexibleAddCard = styled(Card)`
+const FlexibleAddCard = styled.div`
   width: 260px;
+  height: 104px;
   text-align: center;
   vertical-align: middle;
   opacity: 0.5;
+  cursor: pointer;
+  background-color: #ffed99;
+  border: 0px solid #686d76;
 
   @media (min-width: ${sm}px) {
     width: 300px;
+    height: 120px;
   }
 `
 
@@ -84,11 +90,10 @@ function AddCardButton({
 
   return (
     <>
-      <FlexibleAddCard
-        key={`AddCardButton_Card`}
-        size={'default'}
-        onClick={showModal}>
-        <PlusOutlined style={{ fontSize: '70px' }} />
+      <FlexibleAddCard onClick={showModal}>
+        <FlexDiv height="100%">
+          <PlusOutlined style={{ fontSize: '70px' }} />
+        </FlexDiv>
       </FlexibleAddCard>
       <Modal
         title="메모 추가"
@@ -100,7 +105,7 @@ function AddCardButton({
         onCancel={handleCancel}>
         <Select
           key={`AddCardButton_Select`}
-          style={{ width: 120 }}
+          style={{ width: '100%', marginBottom: '5px' }}
           onChange={(value: string) => setCategoryId(CategoryPairs[value])}>
           {categories.map((category: CategoryInfo) => {
             CategoryPairs[category.name] = category._id
@@ -126,13 +131,21 @@ function AddCardButton({
               fallback={BASE64_FALLBACK_IMAGE}
             />
           </Col>
-          <Col span={20}>{currentWeather.description}</Col>
+          <Col span={20}>
+            <FlexDiv height="100%" justify="flex-start">
+              <Typography>
+                {currentWeather.description.toUpperCase()}
+              </Typography>
+            </FlexDiv>
+          </Col>
         </Row>
         <Row>
           <Col span={4} style={{ textAlign: 'center' }}>
             <EnvironmentOutlined />
           </Col>
-          <Col span={20}>{`${GPS.latitude},${GPS.longitude}`}</Col>
+          <Col span={20}>
+            <Typography>{`${GPS.latitude},${GPS.longitude}`}</Typography>
+          </Col>
         </Row>
       </Modal>
     </>

--- a/src/components/AddMemoButton.tsx
+++ b/src/components/AddMemoButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { FormOutlined } from '@ant-design/icons'
+import Link from 'next/link'
+import styled from 'styled-components'
+
+import { sm } from 'src/utils/size'
+import { FlexDiv } from 'style/div'
+
+const FlexibleAddMemo = styled.div`
+  width: 260px;
+  height: 104px;
+  text-align: center;
+  vertical-align: middle;
+  opacity: 0.5;
+  cursor: pointer;
+  background-color: #ffed99;
+  border: 0px solid #686d76;
+  border-top: 2px solid #686d76;
+
+  @media (min-width: ${sm}px) {
+    width: 300px;
+    height: 120px;
+  }
+`
+
+function AddMemoButton() {
+  return (
+    <Link href={`/editor`}>
+      <FlexibleAddMemo>
+        <FlexDiv height="100%">
+          <FormOutlined style={{ fontSize: '50px' }} />
+        </FlexDiv>
+      </FlexibleAddMemo>
+    </Link>
+  )
+}
+
+export default AddMemoButton

--- a/src/components/AddMemoButton.tsx
+++ b/src/components/AddMemoButton.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 
 import { FormOutlined } from '@ant-design/icons'
 import Link from 'next/link'
+import { useRecoilState } from 'recoil'
 import styled from 'styled-components'
 
+import { meState } from 'src/state/me'
 import { sm } from 'src/utils/size'
 import { FlexDiv } from 'style/div'
 
@@ -14,9 +16,9 @@ const FlexibleAddMemo = styled.div`
   vertical-align: middle;
   opacity: 0.5;
   cursor: pointer;
-  background-color: #ffed99;
+  background-color: #a2dbfa;
   border: 0px solid #686d76;
-  border-top: 2px solid #686d76;
+  border-top: 2px solid #e8f0f2;
 
   @media (min-width: ${sm}px) {
     width: 300px;
@@ -25,6 +27,12 @@ const FlexibleAddMemo = styled.div`
 `
 
 function AddMemoButton() {
+  const [me] = useRecoilState(meState)
+
+  if (!me || !me._id) {
+    return <></>
+  }
+
   return (
     <Link href={`/editor`}>
       <FlexibleAddMemo>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -5,7 +5,11 @@ import 'normalize.css'
 import 'antd/dist/antd.css'
 import { useRecoilState, useSetRecoilState } from 'recoil'
 
-import { categoriesState, loadCategories } from 'src/state/categories'
+import {
+  categoriesState,
+  isCategoryLoadingTriedState,
+  loadCategories,
+} from 'src/state/categories'
 
 import { loadMe, meState } from '../state/me'
 import Header from './Header'
@@ -16,12 +20,14 @@ const { Footer, Content } = Layout
 const MainLayout = ({ children }: { children: JSX.Element }): JSX.Element => {
   const [me, setMe] = useRecoilState(meState)
   const setCategories = useSetRecoilState(categoriesState)
+  const setTry = useSetRecoilState(isCategoryLoadingTriedState)
 
   const loadMyInfo = async () => {
     const meInfo = await loadMe()
     setMe(meInfo)
     if (meInfo && meInfo._id) {
       const categoryInfo = await loadCategories(meInfo._id)
+      setTry(true)
       if (categoryInfo) {
         // 성공했을 시
         setCategories(categoryInfo)

--- a/src/components/memo/MemoView.tsx
+++ b/src/components/memo/MemoView.tsx
@@ -7,6 +7,7 @@ import { MemoInfo } from 'src/types/memo'
 import { WeatherInfo } from 'src/utils/weather'
 
 import AddCardButton from '../AddCardButton'
+import AddMemoButton from '../AddMemoButton'
 import MemoCardItem from './MemoCardItem'
 
 const MemoView = ({
@@ -30,6 +31,10 @@ const MemoView = ({
     <Col span={18}>
       <div className="site-card-wrapper">
         <Row gutter={[30, 30]}>
+          <Col key={`ColAddCardButton`}>
+            <AddCardButton addMemo={addMemo} />
+            <AddMemoButton />
+          </Col>
           {memos
             .sort(
               (a: MemoInfo, b: MemoInfo) =>
@@ -47,9 +52,6 @@ const MemoView = ({
                 </Col>
               )
             })}
-          <Col key={`ColAddCardButton`}>
-            <AddCardButton key={`AddCardButton`} addMemo={addMemo} />
-          </Col>
         </Row>
       </div>
     </Col>

--- a/src/state/categories.ts
+++ b/src/state/categories.ts
@@ -18,6 +18,11 @@ export const isCategoryLoadedState = selector<boolean>({
   },
 })
 
+export const isCategoryLoadingTriedState = atom<boolean>({
+  key: 'isCategoryLoadingTried',
+  default: false,
+})
+
 export const categoryAddAvailState = selector<boolean>({
   key: 'categoryAddAvail',
   get: ({ get }) => {

--- a/src/utils/useMemos.ts
+++ b/src/utils/useMemos.ts
@@ -65,16 +65,19 @@ export default function useMemos() {
       gps,
     }
     try {
-      await kaxios({
+      const res = await kaxios({
         url: `/memo`,
         method: 'post',
         data: body,
       })
+      loadMemos(userId)
+      setLoading(false)
+      return res.data
     } catch (e) {
       console.error(e)
+      loadMemos(userId)
+      setLoading(false)
     }
-    loadMemos(userId)
-    setLoading(false)
   }
 
   const deleteMemo = async (memoId: string) => {


### PR DESCRIPTION
### PR 내용


#### 1. 메모 추가 버튼 UI 변경

메모 추가 버튼 UI를 변경했습니다. 색깔이나 스타일 더 괜찮은 의견 있다면 피드백 부탁드립니다!

![image](https://user-images.githubusercontent.com/28820058/122687030-406bfb80-d24f-11eb-83be-87914266ce8c.png)

- 위 버튼 : 메모 추가 카드
- 아래 버튼 : 메모 추가 링크로 이동

#### 2. 메모 추가 기능 구현

메모 추가 기능을 구현했습니다. 메인의 메모추가 중 아래 버튼을 이용해서 링크가 됩니다. url은 parameter 가 없는 `/editor` 값입니다. 급하게 만드느라 버그가 있을 수 있습니다. 테스트 꼭 부탁드립니다🙏🙏

<br/>

**새 메모를 추가할 경우**

![image](https://user-images.githubusercontent.com/28820058/122687222-43b3b700-d250-11eb-9ff2-2b9b0b30ec47.png)

- 카테고리 선택 가능

<br/>

**기존 메모를 수정할 경우**

![image](https://user-images.githubusercontent.com/28820058/122687210-34cd0480-d250-11eb-9cf9-dc5205983260.png)

- 카테고리가 fix됨, 선택 불가
 
<br/>

**기존 카테고리가 없이 메모 추가 버튼을 눌렀을 경우**

![image](https://user-images.githubusercontent.com/28820058/122687302-b02eb600-d250-11eb-87ec-78bd8679cc9c.png)

- 경고창 이후 메인페이지로 리턴

<br/>

#### 3. 메모 추가 레이아웃 변경

메모 추가 레이아웃을 살짝 손봤습니다.

![image](https://user-images.githubusercontent.com/28820058/122687015-29c5a480-d24f-11eb-87cf-786e089fb126.png)

<br/>

#### 기타

모바일 및 데스크탑 반응형을 고려해서 만들었습니다!